### PR TITLE
migrate: add Docker setup for backend deployment

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,7 +2,7 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [main, develop, feat/*]
+    branches: [main, develop, feat/*, migrate/*]
   pull_request:
     branches: [main, develop]
 
@@ -24,30 +24,33 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install pnpm
+        run: npm install -g pnpm
+
       - name: Install dependencies
-        run: npm install
+        run: pnpm install
 
       - name: Check Prettier formatting
         run: |
-          cd frontend && npm run format:check
-          cd ../backend && npm run format:check
+          cd frontend && pnpm run format:check
+          cd ../backend && pnpm run format:check
 
       - name: Run ESLint
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Build project
-        run: npm run build
+        run: pnpm run build
 
       - name: Run frontend unit tests
-        run: npm run test:run
+        run: pnpm run test:run
         working-directory: ./frontend
 
       - name: Run backend unit tests
-        run: npm run test:run
+        run: pnpm run test:run
         working-directory: ./backend
 
       - name: Install Playwright Browsers
-        run: npx playwright install chromium
+        run: pnpm exec playwright install chromium
 
       - name: Find available port and start backend server
         run: |
@@ -56,7 +59,7 @@ jobs:
           echo "BACKEND_PORT=$PORT" >> $GITHUB_ENV
 
           cd backend
-          PORT=$PORT npm run start &
+          PORT=$PORT pnpm run start &
           sleep 5
           curl --retry 10 --retry-delay 1 --retry-connrefused "http://localhost:$PORT/?query=%7Bhealth%7Bstatus%7D%7D"
         env:
@@ -69,7 +72,7 @@ jobs:
       # Smoke tests temporarily disabled due to CI environment issues with onboarding modal
       # TODO: Re-enable once onboarding modal blocking issue is resolved in CI
       # - name: Run smoke tests
-      #   run: npx playwright test smoke.spec.ts --project=chromium
+      #   run: pnpm exec playwright test smoke.spec.ts --project=chromium
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+logs
+.env
+*.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-slim
+
+RUN npm install -g pnpm
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm run build
+
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  backend:
+    build: ./backend
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    env_file:
+      - ./backend/.env
+    environment:
+      - NODE_ENV=production
+      - MONGODB_URI=mongodb://mongo:27017
+    depends_on:
+      mongo:
+        condition: service_healthy
+
+  mongo:
+    image: mongo:8
+    restart: unless-stopped
+    volumes:
+      - mongo_data:/data/db
+    healthcheck:
+      test: mongosh --eval "db.runCommand('ping').ok" --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
Add Dockerfile, docker-compose.yml, and .dockerignore to enable containerized deployment of the backend and MongoDB on Oracle Cloud VM.